### PR TITLE
feat(core): switch to ndjson for the index format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,12 @@ This makes it very easy to add new files to a archive as move files can just be 
 ![TarFileBackground](./static/TarFileBackground.png)
 
 ### Tar Index
-TAR Index (.tar.index) is a JSON document containing the file location and size inside of a tar file. with this index a tar file can be randomly read.
+TAR Index (.tar.index) is a NDJSON document containing the file location and size inside of a tar file. with this index a tar file can be randomly read.
 
 ![TarFileIndex](./static/TarFileIndex.png)
 
 ```typescript
 /** Mapping of path -> index records */
-type TarIndex = TarIndexFile[];
 
 interface TarIndexFile [ 
     string, // Name of the file @see header.path
@@ -46,13 +45,11 @@ interface TarIndexFile [
 #### Example Index
 
 ```json
-[
-  ["src/create/tar.to.ttiles.ts",1536,2610],
-  ["src/index.ts",5120,38],
-  ["src/log.ts",6144,163],
-  ["src/commands/info.ts",7680,1069],
-  ["src/commands/create.ts",9728,1280]
-]
+["src/create/tar.to.ttiles.ts",1536,2610]
+["src/index.ts",5120,38]
+["src/log.ts",6144,163]
+["src/commands/info.ts",7680,1069]
+["src/commands/create.ts",9728,1280]
 ```
 
 ## Future investigation

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -22,9 +22,9 @@ export class CreateCotar extends Command {
     logger.debug({ indexPath: args.inputFile + '.index' }, 'Index:Load');
     const sourceIndex = await fs.readFile(args.inputFile + '.index');
 
-    const index = JSON.parse(sourceIndex.toString());
+    const index = sourceIndex.toString().split('\n');
 
-    const cotar = await Cotar.create(source, index);
+    const cotar = new Cotar(source, index);
     logger.info({ fileName: args.inputFile, files: cotar.index.size }, 'Cotar.Loaded');
   }
 }

--- a/packages/cli/src/create/create.index.ts
+++ b/packages/cli/src/create/create.index.ts
@@ -1,5 +1,5 @@
 import { TarReader } from '@cotar/core';
-import { createWriteStream, promises as fs } from 'fs';
+import { promises as fs } from 'fs';
 import type { Logger } from 'pino';
 
 export async function toTarIndex(filename: string, indexFileName: string, logger: Logger): Promise<void> {

--- a/packages/cli/src/create/create.index.ts
+++ b/packages/cli/src/create/create.index.ts
@@ -5,9 +5,9 @@ import type { Logger } from 'pino';
 export async function toTarIndex(filename: string, indexFileName: string, logger: Logger): Promise<void> {
   const fd = await fs.open(filename, 'r');
   logger.info({ index: indexFileName }, 'Cotar.Index:Start');
-  const outputBuffer = createWriteStream(indexFileName);
   const startTime = Date.now();
 
-  const fileCount = await TarReader.index(fd, outputBuffer, logger);
-  logger.info({ index: indexFileName, count: fileCount, duration: Date.now() - startTime }, 'Cotar.Index:Created');
+  const lines = await TarReader.index(fd, logger);
+  await fs.writeFile(indexFileName, lines.join('\n'));
+  logger.info({ index: indexFileName, count: lines.length, duration: Date.now() - startTime }, 'Cotar.Index:Created');
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,7 +15,7 @@ import { Cotar } from '@cotar/core';
 import { SourceAwsS3 } from '@cogeotiff/source-aws'
 
 const source = SourceAwsS3.fromUri('s3://linz-basemaps/topographic.tar');
-const tarIndex = JSON.parse(fs.readFileSync('./file.tar.index'));
+const tarIndex = fs.readFileSync('./file.tar.index').toString().split('\n');
 
 const cotar = new Cotar(source, index);
 
@@ -27,11 +27,11 @@ Creating indexes, indexes can be created using the `@cotar/cli` package or progr
 
 ```typescript
 import { TarReader } from '@cotar/core'
-import * as fs from 'fs';
+import * as fs from 'fs/promises';
 
 const fd = await fs.open('tarFile.tar', 'r');
-const outputStream = fs.createWriteStream('tarFile.tar.index');
-const fileCount = await TarReader.index(readBytes, outputStream);
+const tarIndex = await TarReader.index(readBytes, outputStream);
+await fs.write('tarFile.tar.index', tarIndex.join('\n'))
 
 await fd.close();
 ```

--- a/packages/core/src/__test__/cotar.test.ts
+++ b/packages/core/src/__test__/cotar.test.ts
@@ -1,7 +1,6 @@
 import { ChunkSource } from '@cogeotiff/chunk';
 import o from 'ospec';
 import { Cotar } from '../cotar';
-import { TarIndex } from '../tar.index';
 
 export class MemorySource extends ChunkSource {
   chunkSize: number;
@@ -29,20 +28,16 @@ export class MemorySource extends ChunkSource {
 }
 
 o.spec('Cotar', () => {
-  const tarIndex: TarIndex = [
-    ['tiles/0/0/0.pbf.gz', 0, 1],
-    ['tiles/1/1/1.pbf.gz', 4, 4],
+  const tarIndex: string[] = [
+    JSON.stringify(['tiles/0/0/0.pbf.gz', 0, 1]),
+    JSON.stringify(['tiles/1/1/1.pbf.gz', 4, 4]),
   ];
-  o('should load index', async () => {
-    const cotar = await Cotar.create(new MemorySource('Tar', '0123456789'), tarIndex);
 
-    o(cotar.index.get(tarIndex[0][0])).deepEquals(tarIndex[0]);
-    o(cotar.index.get(tarIndex[1][0])).deepEquals(tarIndex[1]);
-  });
   o('should load a tile', async () => {
-    const cotar = await Cotar.create(new MemorySource('Tar', '0123456789'), tarIndex);
-    o(cotar.index.get(tarIndex[0][0])).deepEquals(tarIndex[0]);
-    o(cotar.index.get(tarIndex[1][0])).deepEquals(tarIndex[1]);
+    const cotar = new Cotar(new MemorySource('Tar', '0123456789'), tarIndex);
+
+    o(cotar.find('tiles/0/0/0.pbf.gz')).deepEquals(JSON.parse(tarIndex[0]));
+    o(cotar.find('tiles/1/1/1.pbf.gz')).deepEquals(JSON.parse(tarIndex[1]));
 
     const tile0 = await cotar.get('tiles/0/0/0.pbf.gz');
     o(tile0).notEquals(null);

--- a/packages/core/src/cotar.ts
+++ b/packages/core/src/cotar.ts
@@ -5,27 +5,34 @@ export class Cotar {
   source: ChunkSource;
 
   index: Map<string, TarIndexRecord> = new Map();
-  indexSource: TarIndexRecord[];
+  indexSource: string[];
 
-  constructor(source: ChunkSource, index: TarIndexRecord[]) {
+  /**
+   * @param source Chunked source of the tar files
+   * @param index Raw NDJSON lines of the index
+   */
+  constructor(source: ChunkSource, index: string[]) {
     this.source = source;
     this.indexSource = index;
   }
 
-  /** Initialize the cache */
-  init(): void {
-    if (this.index.size > 0) return;
-    for (const r of this.indexSource) this.index.set(r[0], r);
-  }
+  /** Search the raw input data looking for the line that  */
+  find(fileName: string, low = 0, high = this.indexSource.length - 1): TarIndexRecord | null {
+    const searchString = `["${fileName}"`;
 
-  static async create(source: ChunkSource, index: TarIndexRecord[]): Promise<Cotar> {
-    const cotar = new Cotar(source, index);
-    cotar.init();
-    return cotar;
+    if (low > high) return null;
+    const mid = Math.floor((low + high) / 2);
+    const midData = this.indexSource[mid];
+
+    const testString = midData.slice(0, searchString.length);
+
+    if (searchString === testString) return JSON.parse(midData);
+    if (searchString < testString) return this.find(fileName, low, mid - 1);
+    return this.find(fileName, mid + 1, high);
   }
 
   async get(fileName: string, l?: LogType): Promise<null | ArrayBuffer> {
-    const index = this.index.get(fileName);
+    const index = this.find(fileName);
     if (index == null) return null;
 
     const [, offset, size] = index;

--- a/packages/core/src/cotar.ts
+++ b/packages/core/src/cotar.ts
@@ -16,7 +16,11 @@ export class Cotar {
     this.indexSource = index;
   }
 
-  /** Search the raw input data looking for the line that  */
+  /**
+   * Search the index looking for the file
+   * @param fileName file to search for
+   * @returns the index if found, null otherwise
+   */
   find(fileName: string, low = 0, high = this.indexSource.length - 1): TarIndexRecord | null {
     const searchString = `["${fileName}"`;
 
@@ -31,6 +35,12 @@ export class Cotar {
     return this.find(fileName, mid + 1, high);
   }
 
+  /**
+   * Read a file from a cotar
+   * @param fileName File to read
+   * @param l optional logger for additional trace metrics
+   * @returns the file's contents or null if it cannot be found
+   */
   async get(fileName: string, l?: LogType): Promise<null | ArrayBuffer> {
     const index = this.find(fileName);
     if (index == null) return null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,3 @@
 export { Cotar } from './cotar';
-export { TarIndex, TarIndexRecord } from './tar.index';
+export { TarIndexRecord } from './tar.index';
 export { TarHeader, TarReader } from './tar';

--- a/packages/core/src/tar.index.ts
+++ b/packages/core/src/tar.index.ts
@@ -1,2 +1,1 @@
 export type TarIndexRecord = [string, number, number];
-export type TarIndex = TarIndexRecord[];


### PR DESCRIPTION
BREAKING CHANGE: this switches from a json index file to a NDJSON index file

The primary driver is performance when working with largeish indexes 500,000+ records the parsing of the JSON is taking multiple seconds in a lambda function. By switching to a NDJSON on the lines that need to be parsed are which greatly reduces the inital load time of a cotar

**Benchmarks**
Using a AWS t3.micro, loading in a index with 650,000 records (30MB) and finding a random file out of the index.

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| JSON Index| 1.206 ± 0.052 | 1.158 | 1.304 | 3.87 ± 0.17 |
| NDJSON Index| 0.311 ± 0.002 | 0.308 | 0.315 | 1.00 |
