### PR TITLE
fix(core): break early if a empty slot in the hash map is empty

### DIFF
--- a/packages/cli/src/create/create.index.ts
+++ b/packages/cli/src/create/create.index.ts
@@ -1,6 +1,7 @@
-import { CotarIndexBuilder } from '@cotar/core';
+import { LogType, SourceMemory } from '@cogeotiff/chunk';
+import { CotarIndexBinary, CotarIndexBuilder, CotarIndexNdjson, TarReader } from '@cotar/core';
+import { toArrayBuffer } from '@cotar/core/build/src/binary/build.binary';
 import { promises as fs } from 'fs';
-import type { LogType } from '@cogeotiff/chunk';
 
 export async function toTarIndex(
   filename: string,
@@ -21,4 +22,11 @@ export async function toTarIndex(
     { index: indexFileName, count, size: buffer.length, duration: Date.now() - startTime },
     'Cotar.Index:Created',
   );
+
+  const index = binary
+    ? new CotarIndexBinary(new SourceMemory('', toArrayBuffer(buffer)))
+    : new CotarIndexNdjson(buffer.toString());
+
+  await TarReader.validate(fd, index, logger);
+  await fd.close();
 }

--- a/packages/core/src/__test__/tar.test.ts
+++ b/packages/core/src/__test__/tar.test.ts
@@ -57,7 +57,7 @@ o.spec('TarReader', () => {
     const source = await fs.open(tarFilePath, 'r');
 
     const res = await CotarIndexBuilder.create(source, CotarIndexBuilder.NdJson);
-    fs.writeFile(tarFileIndexPath, res.buffer);
+    await fs.writeFile(tarFileIndexPath, res.buffer);
 
     await source.close();
 
@@ -66,6 +66,7 @@ o.spec('TarReader', () => {
 
     const tarIndex = tarIndexRaw
       .toString()
+      .trim()
       .split('\n')
       .map((c) => JSON.parse(c));
 

--- a/packages/core/src/binary/__test__/binary.test.ts
+++ b/packages/core/src/binary/__test__/binary.test.ts
@@ -1,13 +1,14 @@
 import { SourceMemory } from '@cogeotiff/chunk';
+import { SourceFile } from '@cogeotiff/source-file';
+import * as cp from 'child_process';
 import * as fh from 'farmhash';
+import { promises as fs } from 'fs';
+import { FileHandle } from 'fs/promises';
 import o from 'ospec';
 import path from 'path';
 import { CotarIndexBinary, IndexHeaderSize, IndexRecordSize } from '..';
 import { Cotar } from '../../cotar';
-import * as cp from 'child_process';
-import { promises as fs } from 'fs';
-import { FileHandle } from 'fs/promises';
-import { SourceFile } from '@cogeotiff/source-file';
+import { TarReader } from '../../tar';
 import { CotarIndexBinaryBuilder, toArrayBuffer } from '../build.binary';
 
 function abToChar(buf: ArrayBuffer | null, offset: number): string | null {
@@ -79,6 +80,7 @@ o.spec('CotarBinary', () => {
     const source = new SourceFile(tarFilePath);
     const sourceIndex = new SourceFile(tarFileIndexPath);
 
+    const index = new CotarIndexBinary(sourceIndex);
     const cotar = new Cotar(source, new CotarIndexBinary(sourceIndex));
 
     const fileData = await cotar.get('binary.test.js');
@@ -87,5 +89,8 @@ o.spec('CotarBinary', () => {
 
     const fakeFile = await cotar.get('fake.file.md');
     o(fakeFile).equals(null);
+
+    // Should validate
+    await TarReader.validate(fd, index);
   });
 });

--- a/packages/core/src/cotar.index.ts
+++ b/packages/core/src/cotar.index.ts
@@ -1,16 +1,11 @@
 import { LogType } from '@cogeotiff/chunk';
 import { CotarIndexBinaryBuilder } from './binary/build.binary';
 import { CotarIndexNdjsonBuilder } from './ndjson/build.ndjson';
-import { AsyncFileDescriptor, AsyncFileRead, TarIndexResult } from './tar.index';
-
-export enum CotarIndexType {
-  Binary,
-  NdJson,
-}
+import { AsyncFileDescriptor, AsyncFileRead, CotarIndexType, TarIndexResult } from './tar.index';
 
 export const CotarIndexBuilder = {
   Binary: CotarIndexType.Binary,
-  NdJson: CotarIndexType.NdJson,
+  NdJson: CotarIndexType.Ndjson,
   create(
     fd: AsyncFileRead | AsyncFileDescriptor,
     type: CotarIndexType = CotarIndexType.Binary,
@@ -19,7 +14,7 @@ export const CotarIndexBuilder = {
     switch (type) {
       case CotarIndexType.Binary:
         return CotarIndexBinaryBuilder.create(fd, logger);
-      case CotarIndexType.NdJson:
+      case CotarIndexType.Ndjson:
         return CotarIndexNdjsonBuilder.create(fd, logger);
       default:
         throw new Error('Unknown index type:' + type);

--- a/packages/core/src/cotar.ts
+++ b/packages/core/src/cotar.ts
@@ -1,10 +1,13 @@
 import { ChunkSource, LogType } from '@cogeotiff/chunk';
+import { CotarIndexType } from './tar.index';
 
 export interface CotarIndexRecord {
   offset: number;
   size: number;
 }
 export interface CotarIndex {
+  /** Type of index */
+  type: CotarIndexType;
   /** Number of records */
   size: number;
   /** Find the offset/size of a record */

--- a/packages/core/src/ndjson/build.ndjson.ts
+++ b/packages/core/src/ndjson/build.ndjson.ts
@@ -1,6 +1,7 @@
 import { LogType } from '@cogeotiff/chunk';
+import { CotarIndexNdjson } from '.';
 import { TarReader } from '../tar';
-import { AsyncFileRead, AsyncFileDescriptor, TarIndexResult } from '../tar.index';
+import { AsyncReader, TarIndexResult } from '../tar.index';
 
 export const CotarIndexNdjsonBuilder = {
   /**
@@ -9,7 +10,7 @@ export const CotarIndexNdjsonBuilder = {
    * @param logger optional logger for extra information
    * @returns
    */
-  async create(getBytes: AsyncFileRead | AsyncFileDescriptor, logger?: LogType): Promise<TarIndexResult> {
+  async create(getBytes: AsyncReader, logger?: LogType): Promise<TarIndexResult> {
     if (typeof getBytes !== 'function') getBytes = TarReader.toFileReader(getBytes);
 
     let fileCount = 0;
@@ -32,5 +33,10 @@ export const CotarIndexNdjsonBuilder = {
     lines.sort();
 
     return { buffer: Buffer.from(lines.join('\n')), count: lines.length };
+  },
+  /** Validate that the index matches the input file */
+  async validate(getBytes: AsyncReader, index: Buffer, logger?: LogType): Promise<void> {
+    const binIndex = new CotarIndexNdjson(index.toString());
+    return TarReader.validate(getBytes, binIndex, logger);
   },
 };

--- a/packages/core/src/ndjson/index.ts
+++ b/packages/core/src/ndjson/index.ts
@@ -1,7 +1,9 @@
 import { LogType } from '@cogeotiff/chunk';
 import { CotarIndex, CotarIndexRecord } from '../cotar';
+import { CotarIndexType } from '../tar.index';
 
 export class CotarIndexNdjson implements CotarIndex {
+  type = CotarIndexType.Ndjson;
   source: string[];
   constructor(source: string) {
     this.source = source.split('\n');

--- a/packages/core/src/tar.index.ts
+++ b/packages/core/src/tar.index.ts
@@ -18,9 +18,14 @@ export type AsyncFileReader = (
 /** Simple interface that should be similar to the output of fs.open() */
 export type AsyncFileDescriptor = { read: AsyncFileReader };
 
+export type AsyncReader = AsyncFileRead | AsyncFileDescriptor;
+
 export interface TarIndexBuilder {
   /** Create a index from a file  */
   create(f: AsyncFileRead | AsyncFileDescriptor, logger?: LogType): Promise<TarIndexResult>;
+
+  /** Validate that a index matches the file */
+  validate(f: AsyncFileRead | AsyncFileDescriptor, index: Buffer, logger?: LogType): Promise<void>;
 }
 
 export interface TarIndexResult {
@@ -28,4 +33,9 @@ export interface TarIndexResult {
   count: number;
   /** Output buffer */
   buffer: Buffer;
+}
+
+export enum CotarIndexType {
+  Binary = 'binary',
+  Ndjson = 'ndjson',
 }


### PR DESCRIPTION
`allocUnsafe` may contain random data which meant the reader was unable to determine if the slot actually had a record in or was just random data, switching to allocating a empty buffer fixes this