### PR TITLE
build: Update the github action token secret.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,5 +13,3 @@ jobs:
 
       - name: Create test tar
         run: yarn run test-create-data
-
-      - uses: blacha/hyperfine-action@v1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,8 @@ name: release-please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment:
+      name: prod
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
@@ -20,10 +22,8 @@ jobs:
   publish-release:
     needs: release-please
     runs-on: ubuntu-latest
-
     environment:
       name: prod
-      
     if: ${{ needs.release-please.outputs.releases_created }}
     steps:
       - name: Build and test

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           command: manifest
           release-type: node
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LI_GITHUB_ACTION_TOKEN }}
 
   publish-release:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,10 @@ jobs:
   publish-release:
     needs: release-please
     runs-on: ubuntu-latest
+
+    environment:
+      name: prod
+      
     if: ${{ needs.release-please.outputs.releases_created }}
     steps:
       - name: Build and test


### PR DESCRIPTION
#### Description
Github token been managed by https://github.com/linz/github-tf/blob/master/src/repo/repo.cotar.ts. So we need to update the name.



#### Intention

- Match the secret name `LI_GITHUB_ACTION_TOKEN`
- Remove third party action `blacha/hyperfine-action@v1`



#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
